### PR TITLE
Added information about running act-service at localhost

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ To annotated a sequence initialize a new ``BioSeqAnn`` object and then pass the 
     response = typeseq_get(seq, imgthla_version="3.31.0")
 
 
-> You must have `act-service`_ running at localhost (port=443).
+  You must have `act-service`_ running at localhost (port=80).
 
 
 CLI

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,9 @@ To annotated a sequence initialize a new ``BioSeqAnn`` object and then pass the 
     response = typeseq_get(seq, imgthla_version="3.31.0")
 
 
+> You must have `act-service`_ running at localhost (port=443).
+
+
 CLI
 ------------
 
@@ -107,3 +110,4 @@ This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypack
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 .. _`ACT Service`: http://act.b12x.org
+.. _`act-service`: https://github.com/nmdp-bioinformatics/act-service.git


### PR DESCRIPTION
closes #10 

As a package, I think that a user should read this explicitly in README that it needs act-service running at localhost. I look forward to your view on this.
@pbashyal-nmdp 